### PR TITLE
Add mirror command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,51 @@ You can also copy from znodes to a JSON file:
 (CONNECTED) /> cp zk://localhost:2181/something json://!tmp!backup.json/ true true
 ```
 
+Mirroring one path to another path in ZK or from ZK to a JSON file or from the
+filesystem or a JSON to ZK is supported. Mirroring replaces the destination path
+with the content and structure of the source path.
+
+```
+(CONNECTED) /> create /source/znode1/znode11 'Hello' false false true
+(CONNECTED) /> create /source/znode2 'Hello' false false true
+(CONNECTED) /> create /target/znode1/znode12 'Hello' false false true
+(CONNECTED) /> create /target/znode3 'Hello' false false true
+(CONNECTED) /> tree
+.
+├── target
+│   ├── znode3
+│   ├── znode1
+│   │   ├── znode12
+├── source
+│   ├── znode2
+│   ├── znode1
+│   │   ├── znode11
+├── zookeeper
+│   ├── config
+│   ├── quota
+(CONNECTED) /> mirror /source /target
+Are you sure you want to replace /target with /source? [y/n]:
+y
+Mirroring took 0.04 secs
+(CONNECTED) /> tree
+.
+├── target
+│   ├── znode2
+│   ├── znode1
+│   │   ├── znode11
+├── source
+│   ├── znode2
+│   ├── znode1
+│   │   ├── znode11
+├── zookeeper
+│   ├── config
+│   ├── quota
+(CONNECTED) /> create /target/znode4 'Hello' false false true
+(CONNECTED) /> mirror /source /target false false true
+Mirroring took 0.03 secs
+(CONNECTED) />
+```
+
 Sometimes you want to debug watches in ZooKeeper - i.e.: how often do watches fire
 under a given path? You can easily do that with the watch command.
 

--- a/zk_shell/async_walker.py
+++ b/zk_shell/async_walker.py
@@ -3,6 +3,9 @@
 from collections import deque, namedtuple
 import threading
 import time
+from kazoo.exceptions import (
+    NoNodeError,
+)
 
 
 class WalkContext(object):
@@ -80,9 +83,11 @@ class AsyncWalker(object):
             if vpath:
                 yield vpath
 
-            for child in self.client.get_children(full_path):
-                result = self.client.exists_async("%s/%s" % (full_path, child))
-                ctxt.add_candidate(vpath, child, result)
-
+                try:
+                    for child in self.client.get_children(full_path):
+                        result = self.client.exists_async("%s/%s" % (full_path, child))
+                        ctxt.add_candidate(vpath, child, result)
+                except NoNodeError:
+                    pass
         ctxt.working = False
         validator_.join()

--- a/zk_shell/copy.py
+++ b/zk_shell/copy.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import time
+import shutil
 
 try:
     from urlparse import urlparse
@@ -17,6 +18,7 @@ except ImportError:
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import (
+    NoAuthError,
     NodeExistsError,
     NoNodeError,
     NoChildrenForEphemeralsError,
@@ -52,7 +54,14 @@ def url_join(url_root, child_path):
 
 class CopyError(Exception):
     """ base exception for Copy errors """
-    pass
+
+    def __init__(self, message, early_error=False):
+        super(CopyError, self).__init__(message)
+        self._early_error = early_error
+
+    @property
+    def is_early_error(self):
+        return self._early_error
 
 
 class PathValue(object):
@@ -167,10 +176,22 @@ class Proxy(ProxyType("ProxyBase", (object,), {})):
     def children_of(self):
         raise NotImplementedError("children_of must be implemented")
 
-    def copy(self, dst, recursive, max_items):
+    def delete_path_recursively(self):
+        raise NotImplementedError("delete_path must be implemented")
+
+    def copy(self, dst, recursive, max_items, mirror):
+        opname = "Copy" if not mirror else "Mirror"
+
         # basic sanity check
+        if mirror and self.scheme == "zk" and dst.scheme == "file":
+            raise CopyError("Mirror from zk to fs isn't supported", True)
+
         if recursive and self.scheme == "zk" and dst.scheme == "file":
-            raise CopyError("Recursive copy from zk to fs isn't supported")
+            raise CopyError("Recursive %s from zk to fs isn't supported" %
+                            opname.lower(), True)
+
+        if mirror and not recursive:
+            raise CopyError("Mirroring must be recursive", True)
 
         start = time.time()
 
@@ -179,29 +200,40 @@ class Proxy(ProxyType("ProxyBase", (object,), {})):
 
         with self:
             with dst:
-                self.do_copy(dst)
+                if mirror:
+                    dst_children = set(c for c in dst.children_of())
+
+                self.do_copy(dst, opname)
+
                 if recursive:
                     for i, child in enumerate(self.children_of()):
+                        if mirror and child in dst_children:
+                            dst_children.remove(child)
                         if max_items > 0 and i == max_items:
                             break
                         self.set_url(url_join(src_url, child))
                         dst.set_url(url_join(dst_url, child))
-                        self.do_copy(dst)
+                        self.do_copy(dst, opname)
 
                         # reset to base urls
                         self.set_url(src_url)
                         dst.set_url(dst_url)
 
+                if mirror:
+                    for child in dst_children:
+                        dst.set_url(url_join(dst_url, child))
+                        dst.delete_path_recursively()
+
         end = time.time()
 
-        print("Copying took %.2f secs" % (round(end - start, 2)))
+        print("%sing took %.2f secs" % (opname, round(end - start, 2)))
 
-    def do_copy(self, dst):
+    def do_copy(self, dst, opname):
         if self.verbose:
             if self.async:
-                print("Copying (asynchronously) from %s to %s" % (self.url, dst.url))
+                print("%sing (asynchronously) from %s to %s" % (opname, self.url, dst.url))
             else:
-                print("Copying from %s to %s" % (self.url, dst.url))
+                print("%sing from %s to %s" % (opname, self.url, dst.url))
 
         dst.write_path(self.read_path())
 
@@ -298,6 +330,16 @@ class ZKProxy(Proxy):
 
         return v
 
+    def delete_path_recursively(self):
+        try:
+            self.client.delete(self.path, recursive=True)
+        except NoNodeError:
+            pass
+        except NoAuthError:
+            raise CopyError("Permission denied: Cannot delete %s" % self.path)
+        except ZookeeperError:
+            raise CopyError("Zookeeper server error")
+
     def children_of(self):
         if self.async:
             return AsyncWalker(self.client).walk(self.path.rstrip("/"))
@@ -310,7 +352,12 @@ class ZKProxy(Proxy):
         """
         full_path = "%s/%s" % (root_path, branch_path) if branch_path else root_path
 
-        for child in self.client.get_children(full_path):
+        try:
+            children = self.client.get_children(full_path)
+        except NoNodeError:
+            children = set()
+
+        for child in children:
             child_path = "%s/%s" % (branch_path, child) if branch_path else child
             stat = self.client.exists("%s/%s" % (root_path, child_path))
             if stat is None or stat.ephemeralOwner != 0:
@@ -318,7 +365,6 @@ class ZKProxy(Proxy):
             yield child_path
             for new_path in self.zk_walk(root_path, child_path):
                 yield new_path
-
 
 class FileProxy(Proxy):
     SCHEME = "file"
@@ -346,7 +392,6 @@ class FileProxy(Proxy):
 
     def write_path(self, path_value):
         """ this will overwrite dst path - be careful """
-
         parent_dir = os.path.dirname(self.path)
         try:
             os.makedirs(parent_dir)
@@ -365,6 +410,9 @@ class FileProxy(Proxy):
                 yield path
             for filename in files:
                 yield "%s/%s" % (path, filename) if path != "" else filename
+
+    def delete_path_recursively(self):
+        shutil.rmtree(self.path, True)
 
 
 class JSONProxy(Proxy):
@@ -458,3 +506,10 @@ class JSONProxy(Proxy):
         for child in self._tree.keys():
             if good(child):
                 yield child[offs:]
+
+    def delete_path_recursively(self):
+        if self.path in self._tree:
+            # build a set from the iterable so we don't change the dictionary during iteration
+            for c in set(self.children_of()):
+                self._tree.pop(url_join(self.path, c))
+            self._tree.pop(self.path)

--- a/zk_shell/tests/test_cp_cmds.py
+++ b/zk_shell/tests/test_cp_cmds.py
@@ -41,8 +41,8 @@ class CpCmdsTestCase(ShellTestCase):
         json_file = "%s/backup.json" % (self.temp_dir)
         self.shell.onecmd("cp zk://%s%s json://%s/backup true true" % (
             self.zk_host, src_path, json_file.replace("/", "!")))
-        expected_output = "znode /tests/src in localhost:2181 doesn't exist\n"
-        self.assertEqual(expected_output, self.output.getvalue())
+        expected_output = "znode /tests/src in %s doesn't exist\n" % self.zk_host
+        self.assertIn(expected_output, self.output.getvalue())
 
     def test_cp_json2zk(self):
         """ copy from a json file to a ZK cluster (uncompressed) """
@@ -59,7 +59,7 @@ class CpCmdsTestCase(ShellTestCase):
             "cp json://%s/backup zk://%s/%s/from-json true true" % (
                 json_file.replace("/", "!"), self.zk_host, self.tests_path))
         expected_output = "Path /backup doesn't exist\n"
-        self.assertEqual(expected_output, self.output.getvalue())
+        self.assertIn(expected_output, self.output.getvalue())
 
     def test_cp_local(self):
         """ copy one path to another in the connected ZK cluster """
@@ -81,7 +81,7 @@ class CpCmdsTestCase(ShellTestCase):
             bad_path, "%s/some/other/nonexistent/path" % (self.tests_path)))
         expected_output = "znode %s in 127.0.0.1:2181 doesn't exist\n" % (
             bad_path)
-        self.assertEqual(expected_output, self.output.getvalue())
+        self.assertIn(expected_output, self.output.getvalue())
 
     def test_cp_file2zk(self):
         # FIXME: everything should be treated as binary, expecting strings in ZK

--- a/zk_shell/tests/test_mirror_cmds.py
+++ b/zk_shell/tests/test_mirror_cmds.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+"""test mirror cmds"""
+
+from base64 import b64decode
+import json
+import zlib
+
+from .shell_test_case import PYTHON3, ShellTestCase
+
+
+# pylint: disable=R0904
+class MirrorCmdsTestCase(ShellTestCase):
+    """ mirror tests """
+
+    def test_mirror_zk2zk(self):
+        """ mirror from one zk cluster to another"""
+        src_path = "%s/src" % (self.tests_path)
+        dst_path = "%s/dst" % (self.tests_path)
+        self.shell.onecmd("create %s/nested/znode 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("mirror zk://%s%s zk://%s%s false false true" % (
+            self.zk_host, src_path, self.zk_host, dst_path))
+        self.shell.onecmd("tree %s" % (dst_path))
+        self.shell.onecmd("get %s/nested/znode" % dst_path)
+        expected_output = u""".
+\u251c\u2500\u2500 nested\n\u2502   \u251c\u2500\u2500 znode\nHELLO
+"""
+        self.assertEqual(expected_output, self.output.getvalue())
+
+    def test_mirror_zk2json(self):
+        """ mirror from zk to a json file (uncompressed) """
+        src_path = "%s/src" % (self.tests_path)
+        json_file = "%s/backup.json" % (self.temp_dir)
+
+        self.shell.onecmd("create %s 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested1 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested2 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested1/nested11 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested1/nested12 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested2/nested21 'HELLO' false false true" % (
+            src_path))
+
+        self.shell.onecmd("cp zk://%s/%s json://%s true true" % (
+            self.zk_host, src_path, json_file.replace("/", "!")))
+
+        with open(json_file, "r") as jfp:
+            copied_znodes = json.load(jfp)
+            copied_paths = copied_znodes.keys()
+
+        self.assertIn("/nested1", copied_paths)
+        self.assertIn("/nested1/nested12", copied_paths)
+        self.assertIn("/nested2/nested21", copied_paths)
+
+        self.shell.onecmd("create %s/nested3 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested1/nested13 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("rmr %s/nested2" % src_path)
+        self.shell.onecmd("rmr %s/nested1/nested12" % src_path)
+
+        self.shell.onecmd("mirror zk://%s%s json://%s false false true" % (
+            self.zk_host, src_path, json_file.replace("/", "!")))
+
+        with open(json_file, "r") as jfp:
+            copied_znodes = json.load(jfp)
+            copied_paths = copied_znodes.keys()
+
+        self.assertIn("/nested1", copied_paths)
+        self.assertIn("/nested3", copied_paths)
+        self.assertIn("/nested1/nested13", copied_paths)
+        self.assertNotIn("/nested2", copied_paths)
+        self.assertNotIn("/nested2/nested21", copied_paths)
+        self.assertNotIn("/nested1/nested12", copied_paths)
+
+    def test_mirror_json2zk(self):
+        """ mirror from a json file to a ZK cluster (uncompressed) """
+        src_path = "%s/src" % (self.tests_path)
+        json_file = "%s/backup.json" % (self.temp_dir)
+
+        self.shell.onecmd("create %s/nested1 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested1/znode 'HELLO' false false true" % (
+            src_path))
+
+        json_url = "json://%s/backup" % (json_file.replace("/", "!"))
+
+        zk_url = "zk://%s%s" % (self.zk_host, src_path)
+
+        self.shell.onecmd("cp %s %s true true" % (zk_url, json_url))
+
+        self.shell.onecmd("rmr %s/nested1" % src_path)
+        self.shell.onecmd("create %s/nested2 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested3 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("create %s/nested3/nested31 'HELLO' false false true" % (
+            src_path))
+        self.shell.onecmd("mirror %s %s false false true" % (json_url, zk_url))
+        self.shell.onecmd("tree %s" % src_path)
+        self.shell.onecmd("get %s/nested1/znode" % src_path)
+
+        if PYTHON3:
+            expected_output = '.\n├── nested1\n│   ├── znode\nHELLO\n'
+        else:
+            expected_output = u""".
+\u251c\u2500\u2500 nested1\n\u2502   \u251c\u2500\u2500 znode\nHELLO
+"""
+        self.assertEqual(expected_output, self.output.getvalue())
+
+    def test_mirror_local(self):
+        """ mirror one path to another in the connected ZK cluster """
+        self.shell.onecmd(
+            "create %s/very/nested/znode 'HELLO' false false true" % (
+                self.tests_path))
+        self.shell.onecmd(
+            "create %s/very/nested/znode2 'HELLO' false false true" % (
+                self.tests_path))
+        self.shell.onecmd(
+            "create %s/very/znode3 'HELLO' false false true" % (
+                self.tests_path))
+
+        self.shell.onecmd(
+            "create %s/backup/nested/znode 'HELLO' false false true" % (
+                self.tests_path))
+        self.shell.onecmd(
+            "create %s/backup/znode3foo 'HELLO' false false true" % (
+                self.tests_path))
+
+        self.shell.onecmd("mirror %s/very %s/backup false false true" % (
+            self.tests_path, self.tests_path))
+        self.shell.onecmd("tree %s/backup" % (self.tests_path))
+        expected_output = u""".
+\u251c\u2500\u2500 znode3\n\u251c\u2500\u2500 nested\n\u2502   \u251c\u2500\u2500 znode\n\u2502   \u251c\u2500\u2500 znode2
+"""
+        self.assertEqual(expected_output, self.output.getvalue())
+
+    def test_mirror_local_bad_path(self):
+        """ try mirror non existent path in the local zk cluster """
+        bad_path = "%s/doesnt/exist/path" % (self.tests_path)
+        self.shell.onecmd("mirror %s %s false false true" % (
+            bad_path, "%s/some/other/nonexistent/path" % (self.tests_path)))
+        expected_output = "znode %s in 127.0.0.1:2181 doesn't exist\n" % (
+            bad_path)
+        self.assertIn(expected_output, self.output.getvalue())
+
+    def test_mirror_file2zk(self):
+        myfile = "%s/myfile" % (self.temp_dir)
+        with open(myfile, "w") as fph:
+            fph.writelines(["hello\n", "bye\n"])
+
+        src_path = "file://%s" % (myfile)
+        dst_path = "%s/myfile" % (self.tests_path)
+        self.shell.onecmd("mirror %s %s false false true" % (src_path, dst_path))
+        self.shell.onecmd("get %s" % (dst_path))
+        expected_output =  u"hello\nbye\n\n"
+        self.assertEqual(expected_output, self.output.getvalue())
+
+    def test_mirror_zk2file(self):
+        src_path = "%s/src" % (self.tests_path)
+        myfile = "%s/myfile" % (self.temp_dir)
+        dst_path = "file://%s" % (myfile)
+        self.shell.onecmd("create %s 'HELLO'" % (src_path))
+        self.shell.onecmd("mirror %s %s false false true" % (src_path, dst_path))
+        self.assertEquals("Mirror from zk to fs isn't supported\n", self.output.getvalue())

--- a/zk_shell/util.py
+++ b/zk_shell/util.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 import sys
 
+from distutils.util import strtobool
 
 PYTHON3 = sys.version_info > (3, )
 
@@ -50,6 +51,14 @@ def decoded(s):
         return str.encode(s).decode('unicode_escape')
     else:
         return s.decode('string_escape')
+
+def prompt_yes_no(question):
+    print('%s [y/n]: ' % question)
+    while True:
+        try:
+            return strtobool(raw_input().lower())
+        except ValueError:
+            print('Please respond with \'y\' or \'n\'.\n')
 
 
 class Netloc(namedtuple("Netloc", "host scheme credential")):


### PR DESCRIPTION
Adds a mirror cmd which behaves similarly to cp but deletes all znodes on the dst that do not exist in the src.
The implementation of copy is extended to support both regular copy and mirror. Mirror takes fewer parameters than copy since recursiveness and overwrite are implied.

Tests are based on the copy tests with some modifications to include specific mirror related behavior (deletion of nodes on dst).
