### PR TITLE
Use non-keyword decode for python 2.6 compat

### DIFF
--- a/zk_shell/augumented_client.py
+++ b/zk_shell/augumented_client.py
@@ -138,7 +138,7 @@ class AugumentedClient(KazooClient):
 
         try:
             if value is not None:
-                value = value.decode(encoding="utf-8")
+                value = value.decode("utf-8")
         except UnicodeDecodeError:
             pass
 


### PR DESCRIPTION
When using zk_shell with python 2.6 on CentOS6, I get the following traceback when using 'get'.  PR contains 2.6/2.7 agnostic fix.

```
Traceback (most recent call last):
  File "/usr/bin/zk-shell", line 22, in <module>
    CLI()()
  File "/usr/lib/python2.6/site-packages/zk_shell/cli.py", line 151, in __call__
    shell.run(intro if first else None)
  File "/usr/lib/python2.6/site-packages/zk_shell/augumented_cmd.py", line 208, in run
    self.cmdloop()
  File "/usr/lib64/python2.6/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib64/python2.6/cmd.py", line 219, in onecmd
    return func(arg)
  File "/usr/lib/python2.6/site-packages/zk_shell/shell.py", line 99, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/zk_shell/augumented_cmd.py", line 137, in wrapper
    return func(args[0], params)
  File "/usr/lib/python2.6/site-packages/zk_shell/shell.py", line 128, in wrapper
    return func(self, params)
  File "/usr/lib/python2.6/site-packages/zk_shell/shell.py", line 707, in do_get
    value, _ = self._zk.get(params.path, **kwargs)
  File "/usr/lib/python2.6/site-packages/zk_shell/augumented_client.py", line 141, in get
    value = value.decode(encoding="utf-8")
TypeError: decode() takes no keyword arguments
```
