### PR TITLE
Add an option to connect via a ssh-tunnel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ $ echo "get /foo" | zk-shell --run-from-stdin localhost
 bar
 ```
 
+It's also possible to connect using an SSH tunnel, by specifying a host to use:
+
+```
+$ zk-shell --tunnel ssh-host zk-host
+```
+
 ### Dependencies ###
 
 * Python 2.7, 3.3 or 3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansicolors
 kazoo>=2.0
 nose
 tabulate
+twitter.common.net

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ setup(name='zk_shell',
       packages=find_packages(),
       test_suite="zk_shell.tests",
       scripts=['bin/zk-shell'],
-      install_requires=['ansicolors', 'kazoo>=2.0', 'tabulate'],
-      tests_require=['ansicolors', 'kazoo>=2.0', 'nose', 'tabulate'],
+      install_requires=['ansicolors', 'kazoo>=2.0', 'tabulate', 'twitter.common.net'],
+      tests_require=['ansicolors', 'kazoo>=2.0', 'nose', 'tabulate', 'twitter.common.net'],
       extras_require={
-          'test': ['ansicolors', 'kazoo>=2.0', 'nose', 'tabulate'],
+          'test': ['ansicolors', 'kazoo>=2.0', 'nose', 'tabulate', 'twitter.common.net'],
       },
       include_package_data=True,
       zip_safe=False)

--- a/zk_shell/cli.py
+++ b/zk_shell/cli.py
@@ -19,7 +19,7 @@ except NameError:
 
 class CLIParams(
         namedtuple("CLIParams",
-                   "connect_timeout run_once run_from_stdin sync_connect hosts readonly")):
+                   "connect_timeout run_once run_from_stdin sync_connect hosts readonly tunnel")):
     """
     This defines the running params for a CLI() object. If you'd like to do parameters processing
     from some other point you'll need to fill up an instance of this class and pass it to
@@ -59,6 +59,10 @@ def get_params():
                         action="store_true",
                         default=False,
                         help="Enable readonly.")
+    parser.add_argument("--tunnel",
+                        type=str,
+                        help="Create a ssh tunnel via this host",
+                        default=None)
     parser.add_argument("hosts",
                         nargs="*",
                         help="ZK hosts to connect")
@@ -69,7 +73,8 @@ def get_params():
         params.run_from_stdin,
         params.sync_connect,
         params.hosts,
-        params.readonly)
+        params.readonly,
+        params.tunnel)
 
 
 class StateTransition(Exception):
@@ -120,7 +125,8 @@ class CLI(object):
                       setup_readline=interactive,
                       output=sys.stdout,
                       async=async,
-                      read_only=params.readonly)
+                      read_only=params.readonly,
+                      tunnel=params.tunnel)
 
         if not interactive:
             rc = 0


### PR DESCRIPTION
The new option (`--tunnel`) takes a hostname that will be used to tunnel
to. We select randomly an available ephemeral port, and instead of
connecting directly to the remote zookeeper node, we will connect to
localhost:<random_port>.