### PR TITLE
README.md: Update pex command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can also build a self-contained PEX file:
 ```
 $ pip install pex
 
-$ pex -s . -v -e zk_shell.cli -o zk-shell.pex
+$ pex -v -e zk_shell.cli -o zk-shell.pex .
 
 ```
 


### PR DESCRIPTION
It seems that perhaps the `-s` option was removed from pex in some
version that happened after this was written, as I got the following
with pex 1.0.0.dev3:

    $ pex -s . -v -e zk_shell.cli -o zk-shell.pex
    Usage: pex [-o OUTPUT.PEX] [options] [-- arg1 arg2 ...]

    pex builds a PEX (Python Executable) file based on the given specifications: sources, requirements, their dependencies and other options.

    pex: error: no such option: -s

This updates the pex command to pass `.` instead of `-s .`.