### PR TITLE
Fix the documentation on how to contributed.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 ## Setup
 
 ### Python
-Install local requirements
+
+Install local requirements:
 
 ```
 $ pip install -r requirements.txt --use-mirrors
@@ -22,37 +23,22 @@ On OS X, you can use [brew](http://brew.sh):
 brew install ant automake libtool cppunit
 ```
 
-To start up a ZooKeeper server locally:
-
-```
-$ integration/start.sh 3.5.0 https://github.com/apache/zookeeper/archive/release-3.5.0.tar.gz 2181
-```
-
-To stop:
-
-```
-$ integration/stop.sh 3.5.0
-```
-
 ## Testing
 
-To run tests, you must bootstrap a local ZooKeeper server, see the above section for details.
+To run tests, you must bootstrap a local ZooKeeper server.
 
 For every new command there should be at least a test case. Before pushing any
 changes, always run:
 
 ```
-$ nosetests-2.7 zk_shell/tests/
-$ nosetests-3.3 zk_shell/tests/
+$ ./ensure-zookeeper-env.sh python setup.py nosetests --with-coverage --cover-package=zk_shell
 ```
 
-Alternatively, use `setup.py`:
+Or if you have multiple version of Python:
 
 ```
-$ pip2.7 install nose
-$ python2.7 ./setup.py nosetests -v
-$ pip3.4 install nose
-$ python3.4 ./setup.py nosetests -v
+$ ./ensure-zookeeper-env.sh python2.7 setup.py nosetests --with-coverage --cover-package=zk_shell
+$ ./ensure-zookeeper-env.sh python3.4 setup.py nosetests --with-coverage --cover-package=zk_shell
 ```
 
 ## Style


### PR DESCRIPTION
The documentation mentions that, in order to run the tests, you need to run the
scripts `integration/start.sh`. The script was removed in
32f703dcf8b65347cf34c82496ea44eece0dce6e and replaced with
`./ensure-zookeeper-env.sh`.

Update the documentation to mention the new script and how to run the tests for
multiple versions of Python.