### PR TITLE
feature(session_info): print last_zxid as hex

### DIFF
--- a/zk_shell/shell.py
+++ b/zk_shell/shell.py
@@ -1452,7 +1452,7 @@ class Shell(XCmd):
         > session_info
         state=CONNECTED
         xid=4
-        last_zxid=11
+        last_zxid=0x000000505f8be5b3
         timeout=10000
         client=('127.0.0.1', 60348)
         server=('127.0.0.1', 2181)
@@ -1463,7 +1463,7 @@ sessionid=%s
 auth_info=%s
 protocol_version=%d
 xid=%d
-last_zxid=%d
+last_zxid=0x%.16x
 timeout=%d
 client=%s
 server=%s


### PR DESCRIPTION
The zxid is composed of 64 bits, of which the highest
32 are the epoch (i.e.: they mark the start of new
leader) and the lower 32 are the transactions counter
for that epoch.

Signed-off-by: Raul Gutierrez S <rgs@itevenworks.net>