### PR TITLE
Get defaults hosts from ZK_SHELL_HOSTS env var

### DIFF
--- a/zk_shell/cli.py
+++ b/zk_shell/cli.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from functools import partial
 import argparse
 import logging
+import os
 import signal
 import sys
 
@@ -69,6 +70,7 @@ def get_params():
                         help="Display version and exit.")
     parser.add_argument("hosts",
                         nargs="*",
+                        default=os.getenv('ZK_SHELL_HOSTS').split(','),
                         help="ZK hosts to connect")
     params = parser.parse_args()
     return CLIParams(


### PR DESCRIPTION
This lets one configure their Zookeeper hosts in an environment variable and then be able to launch `zk-shell` with no arguments and have it work. E.g.:

```
$ export ZK_SHELL_HOSTS=$DOCKER_IP:2181

$ zk-shell
Welcome to zk-shell (1.1.1)
(CONNECTING) />
(CONNECTED) /> summary
Created                         Last modified                   Owner                  Name
Sat Mar  4 00:24:05 2017        Sat Mar  4 00:24:05 2017        0x0                    chronos
Sat Mar  4 00:24:27 2017        Sat Mar  4 00:24:27 2017        0x0                    marathon
Sat Mar  4 00:23:22 2017        Sat Mar  4 00:23:22 2017        0x0                    mesos
Sat Mar  4 00:24:01 2017        Sat Mar  4 00:24:01 2017        0x0                    metronome
Wed Dec 31 16:00:00 1969        Wed Dec 31 16:00:00 1969        0x0                    zookeeper
```