### PR TITLE
fix error in copy

### DIFF
--- a/zk_shell/copy.py
+++ b/zk_shell/copy.py
@@ -413,7 +413,7 @@ class FileProxy(Proxy):
     def read_path(self):
         if os.path.isfile(self.path):
             with open(self.path, "r") as fph:
-                return PathValue("".os.path.join(fph.readlines()))
+                return PathValue("".join(os.path.join(fph.readlines())))
         elif os.path.isdir(self.path):
             return PathValue("")
 


### PR DESCRIPTION
The error from below was fixed with this patch.

(CONNECTED) /some/path> cp file:///tmp/solrconfig.xml solrconfig.xml
Traceback (most recent call last):
File "/usr/local/bin/zk-shell", line 22, in 
CLI()()
File "/usr/local/lib/python2.7/dist-packages/zk_shell/cli.py", line 165, in call
shell.run(intro if first else None)
File "/usr/local/lib/python2.7/dist-packages/xcmd/xcmd.py", line 410, in run
self.cmdloop()
File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
stop = self.onecmd(line)
File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
return func(arg)
File "/usr/local/lib/python2.7/dist-packages/xcmd/xcmd.py", line 191, in wrapper
return func(args[0], params)
File "/usr/local/lib/python2.7/dist-packages/zk_shell/shell.py", line 564, in do_cp
self.copy(params, params.recursive, params.overwrite, params.max_items, False)
File "/usr/local/lib/python2.7/dist-packages/zk_shell/shell.py", line 672, in copy
src.copy(dst, recursive, max_items, mirror)
File "/usr/local/lib/python2.7/dist-packages/zk_shell/copy.py", line 209, in copy
self.do_copy(dst, opname)
File "/usr/local/lib/python2.7/dist-packages/zk_shell/copy.py", line 241, in do_copy
dst.write_path(self.read_path())
File "/usr/local/lib/python2.7/dist-packages/zk_shell/copy.py", line 416, in read_path
return PathValue("".os.path.join(fph.readlines()))
AttributeError: 'str' object has no attribute 'os'