### PR TITLE
typo fix

### DIFF
--- a/zk_shell/copy.py
+++ b/zk_shell/copy.py
@@ -413,7 +413,7 @@ class FileProxy(Proxy):
     def read_path(self):
         if os.path.isfile(self.path):
             with open(self.path, "r") as fph:
-                return PathValue("".os.path.join(fph.readlines()))
+                return PathValue(os.path.join(fph.readlines()))
         elif os.path.isdir(self.path):
             return PathValue("")
 

--- a/zk_shell/xclient.py
+++ b/zk_shell/xclient.py
@@ -162,7 +162,7 @@ class XClient(KazooClient):
 
     def set(self, path, value, version=-1):
         """ wraps the default set() and handles encoding (Py3k) """
-        value = to_bytes(value)
+        value = to_bytes("".join(value))
         super(XClient, self).set(path, value, version)
 
     def create(self, path, value=b"", acl=None, ephemeral=False, sequence=False, makepath=False):


### PR DESCRIPTION
hi,
I fixed that small typo ( "".os.path instead of just os.path )

Thanks,
Leonardo