### PR TITLE
Use srvr, not stat for zxid

### DIFF
--- a/zk_shell/shell.py
+++ b/zk_shell/shell.py
@@ -1699,25 +1699,14 @@ child_watches=%s"""
             datasize[idx] = int(dsize)
             sessions[idx] = int(session_count)
 
-            def fetch_zxid(endpoint):
-                zxid = -1
-                try:
-                    stat = self._zk.cmd(hosts_to_endpoints(endpoint), "stat")
-                    for line in stat.split("\n"):
-                        if "Zxid:" in line:
-                            zxid = int(line.split(None)[1], 0)
-                except:
-                    pass
-                return zxid
-
-            # the stat cmd is a bit flaky, so try a few times
-            zxid = -1
-            for i in range(0, stat_retries):
-                zxid = fetch_zxid(endpoint)
-                if zxid != -1:
-                    break
-
-            zxids[idx]= zxid
+            try:
+                srvr = self._zk.cmd(hosts_to_endpoints(endpoint), "srvr")
+                for line in srvr.split("\n"):
+                    if "Zxid:" in line:
+                        zxids[idx] = int(line.split(None)[1], 0)
+                        break
+            except:
+                zxids[idx] = -1
 
         workers = []
         for idx, endpoint in enumerate(endpoints, 1):

--- a/zk_shell/shell.py
+++ b/zk_shell/shell.py
@@ -1698,6 +1698,7 @@ child_watches=%s"""
             ephemerals[idx] = int(eph_count)
             datasize[idx] = int(dsize)
             sessions[idx] = int(session_count)
+            zxids[idx] = -1
 
             try:
                 srvr = self._zk.cmd(hosts_to_endpoints(endpoint), "srvr")
@@ -1706,7 +1707,7 @@ child_watches=%s"""
                         zxids[idx] = int(line.split(None)[1], 0)
                         break
             except:
-                zxids[idx] = -1
+                pass
 
         workers = []
         for idx, endpoint in enumerate(endpoints, 1):


### PR DESCRIPTION
The `stat` command includes the connections. When the number of connections is high, it truncates the output, meaning the zxid is not found (and set to -1).

The `srvr` command only prints out the details on the server, not the connections.

@jeffbean
