### PR TITLE
Adding ability to handle lz4 compressed data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nose>=1.3.7
 tabulate>=0.8.3
 twitter.common.net>=0.3.11
 xcmd>=0.0.3
+lz4>=4.0.2

--- a/zk_shell/copy_util.py
+++ b/zk_shell/copy_util.py
@@ -426,7 +426,7 @@ class FileProxy(Proxy):
             os.makedirs(parent_dir)
         except OSError:
             pass
-        with open(self.path, "w") as fph:
+        with open(self.path, "wb") as fph:
             fph.write(path_value.value)
 
     def children_of(self):

--- a/zk_shell/shell.py
+++ b/zk_shell/shell.py
@@ -1090,8 +1090,7 @@ class Shell(XCmd):
         if value is not None:
             try:
                 value = lz4.frame.decompress(value)
-            except BaseException as err:
-                print(err)
+            except:
                 pass
 
         self.show_output(value)

--- a/zk_shell/shell.py
+++ b/zk_shell/shell.py
@@ -13,6 +13,7 @@ import bisect
 import copy
 import difflib
 import json
+import lz4.frame
 import os
 import re
 import shlex
@@ -1083,6 +1084,14 @@ class Shell(XCmd):
             try:
                 value = zlib.decompress(value)
             except:
+                pass
+
+        # maybe it's lz4 compressed?
+        if value is not None:
+            try:
+                value = lz4.frame.decompress(value)
+            except BaseException as err:
+                print(err)
                 pass
 
         self.show_output(value)

--- a/zk_shell/tests/shell_test_case.py
+++ b/zk_shell/tests/shell_test_case.py
@@ -3,6 +3,7 @@
 """ base test case """
 
 
+import lz4.frame
 import os
 import shutil
 import sys
@@ -105,4 +106,12 @@ class ShellTestCase(unittest.TestCase):
         to create a znode with zlib compressed content.
         """
         compressed = zlib.compress(bytes(value, "utf-8") if PYTHON3 else value)
+        self.client.create(path, compressed, makepath=True)
+
+    def create_lz4_compressed(self, path, value):
+        """
+        ZK Shell doesn't support creating directly from a bytes array so we use a Kazoo client
+        to create a znode with lz4 compressed content.
+        """
+        compressed = lz4.frame.compress(bytes(value, "utf-8") if PYTHON3 else value)
         self.client.create(path, compressed, makepath=True)

--- a/zk_shell/tests/test_basic_cmds.py
+++ b/zk_shell/tests/test_basic_cmds.py
@@ -171,6 +171,13 @@ class BasicCmdsTestCase(ShellTestCase):
         expected_output = "b'some value'\n" if PYTHON3 else "some value\n"
         self.assertEqual(expected_output, self.output.getvalue())
 
+    def test_get_lz4_compressed(self):
+        """ test getting lz4 compressed content out of znode """
+        self.create_lz4_compressed("%s/one" % (self.tests_path), "some value")
+        self.shell.onecmd("get %s/one" % (self.tests_path))
+        expected_output = "b'some value'\n" if PYTHON3 else "some value\n"
+        self.assertEqual(expected_output, self.output.getvalue())
+
     def test_child_count(self):
         """ test child count for a given path """
         self.shell.onecmd("create %s/something ''" % (self.tests_path))


### PR DESCRIPTION
This attempts to decompress data as lz4 compressed data (a common compression algorithm) in get requests and handles compressed data as bytes by using 'wb' mode for writing files to disk. 

Previously doing cp to a file of compressed data would fail since a string is expected when using 'w' mode for files.