### PR TITLE
Update acl.py to support x509 scheme

### DIFF
--- a/zk_shell/acl.py
+++ b/zk_shell/acl.py
@@ -22,6 +22,7 @@ class ACLReader(object):
         "host",
         "ip",
         "sasl",
+        "x509",
         "username_password",  # internal-only: gen digest from user:password
     ]
 


### PR DESCRIPTION
Add support for x509 scheme 
```
set_acls /test 'x509:foo:cdrwa'
Failed to set ACLs: Invalid scheme: x509:foo:cdrwa.
```