### PR TITLE
Allow valid syntax for regex python 3.12

### DIFF
--- a/zk_shell/util.py
+++ b/zk_shell/util.py
@@ -87,9 +87,9 @@ class Netloc(namedtuple("Netloc", "host scheme credential")):
         return cls(host, scheme, credential)
 
 
-_empty = re.compile("\A\s*\Z")
-_valid_host_part = re.compile("(?!-)[a-z\d-]{1,63}(?<!-)$", re.IGNORECASE)
-_valid_ipv4 = re.compile("\A(\d+)\.(\d+)\.(\d+)\.(\d+)\Z")
+_empty = re.compile(r"\A\s*\Z")
+_valid_host_part = re.compile(r"(?!-)[a-z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+_valid_ipv4 = re.compile(r"\A(\d+)\.(\d+)\.(\d+)\.(\d+)\Z")
 
 
 def valid_port(port, start=1, end=65535):


### PR DESCRIPTION
What’s New In Python 3.12

https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

`A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)`